### PR TITLE
feat: adapt ConfidencePanel to interface theme and add global logout …

### DIFF
--- a/frontend/src/app/components/ConfidencePanel.jsx
+++ b/frontend/src/app/components/ConfidencePanel.jsx
@@ -1,7 +1,5 @@
- 
- 
- /**
- *Nivel de Confianza y Transparencia
+/**
+ * Nivel de Confianza y Transparencia
  *
  * Componente: ConfidencePanel
  *
@@ -29,9 +27,9 @@ import { useEffect, useRef, useState } from "react";
  *   <  65 → Baja confianza  (rojo)
  */
 function getConfidenceTier(value) {
-  if (value >= 85) return { color: "#22c55e", bg: "#052e16", label: "Alta" };
-  if (value >= 65) return { color: "#eab308", bg: "#1c1400", label: "Media" };
-  return { color: "#ef4444", bg: "#2d0a0a", label: "Baja" };
+  if (value >= 85) return { color: "#22c55e", label: "Alta", badge: "tier-alta" };
+  if (value >= 65) return { color: "#eab308", label: "Media", badge: "tier-media" };
+  return { color: "#ef4444", label: "Baja", badge: "tier-baja" };
 }
 
 // ─── Sub-componente: barra de un modelo ───────────────────────────────────────
@@ -45,7 +43,7 @@ function ConfidenceBar({ modelKey, data, animDelay = 0 }) {
   const label = data?.label ?? modelKey;
   const tier = getConfidenceTier(value);
 
-  // Animación de entrada con IntersectionObserver (accesible, sin scroll-jank)
+  // Animación de entrada con IntersectionObserver
   useEffect(() => {
     const el = barRef.current;
     if (!el) return;
@@ -60,31 +58,20 @@ function ConfidenceBar({ modelKey, data, animDelay = 0 }) {
   return (
     <div
       ref={barRef}
-      style={{
-        background: "#0f0f0f",
-        border: `1px solid ${tier.color}22`,
-        borderRadius: "12px",
-        padding: "18px 20px",
-        display: "flex",
-        flexDirection: "column",
-        gap: "12px",
-        transition: "border-color 0.3s",
-      }}
+      className="bg-[#f3f7f3] dark:bg-gray-700 rounded-2xl p-5 flex flex-col gap-3 transition-colors"
+      style={{ border: `1px solid ${tier.color}33` }}
     >
       {/* Encabezado */}
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <span style={{ color: "#a3a3a3", fontSize: "13px", fontFamily: "'DM Sans', sans-serif", letterSpacing: "0.04em" }}>
+      <div className="flex justify-between items-center">
+        <span className="text-[#475569] dark:text-gray-400 text-sm font-medium transition-colors">
           {label}
         </span>
         <span
+          className="text-xs font-semibold px-2 py-0.5 rounded-full border transition-colors"
           style={{
             color: tier.color,
-            fontSize: "11px",
-            fontFamily: "'DM Mono', monospace",
-            background: tier.bg,
-            padding: "2px 8px",
-            borderRadius: "20px",
-            border: `1px solid ${tier.color}44`,
+            borderColor: `${tier.color}55`,
+            backgroundColor: `${tier.color}15`,
           }}
         >
           {tier.label}
@@ -93,28 +80,15 @@ function ConfidenceBar({ modelKey, data, animDelay = 0 }) {
 
       {/* Porcentaje grande */}
       <div
-        style={{
-          fontSize: "36px",
-          fontWeight: "700",
-          fontFamily: "'DM Mono', monospace",
-          color: tier.color,
-          lineHeight: 1,
-          letterSpacing: "-0.02em",
-        }}
+        className="leading-none font-black"
+        style={{ color: tier.color, fontSize: "36px", letterSpacing: "-0.02em" }}
       >
         {value.toFixed(1)}
-        <span style={{ fontSize: "18px", color: "#6b7280", marginLeft: "2px" }}>%</span>
+        <span className="text-lg text-[#94a3b8] dark:text-gray-500 ml-1 font-semibold">%</span>
       </div>
 
       {/* Barra de progreso */}
-      <div
-        style={{
-          height: "6px",
-          background: "#1f1f1f",
-          borderRadius: "99px",
-          overflow: "hidden",
-        }}
-      >
+      <div className="h-1.5 bg-[#e4ede4] dark:bg-gray-600 rounded-full overflow-hidden transition-colors">
         <div
           style={{
             height: "100%",
@@ -122,20 +96,13 @@ function ConfidenceBar({ modelKey, data, animDelay = 0 }) {
             background: `linear-gradient(90deg, ${tier.color}88, ${tier.color})`,
             borderRadius: "99px",
             transition: `width 0.9s cubic-bezier(0.4, 0, 0.2, 1) ${animDelay}ms`,
-            boxShadow: `0 0 8px ${tier.color}66`,
+            boxShadow: `0 0 6px ${tier.color}55`,
           }}
         />
       </div>
 
       {/* Texto legible */}
-      <p
-        style={{
-          margin: 0,
-          color: "#6b7280",
-          fontSize: "12px",
-          fontFamily: "'DM Sans', sans-serif",
-        }}
-      >
+      <p className="m-0 text-[#475569] dark:text-gray-400 text-xs transition-colors">
         {display}
       </p>
     </div>
@@ -148,7 +115,7 @@ export default function ConfidencePanel({ confidenceSummary }) {
   // Fallback: si el padre aún no tiene datos, mostrar esqueleto
   if (!confidenceSummary) {
     return (
-      <div style={panelWrapperStyle}>
+      <div className="bg-[#f3f7f3] dark:bg-gray-700 border border-[#c5e1a5] dark:border-gray-600 rounded-2xl p-5 w-full transition-colors">
         <SkeletonBar />
         <SkeletonBar />
       </div>
@@ -158,96 +125,38 @@ export default function ConfidencePanel({ confidenceSummary }) {
   const { damage_model, ripeness_model } = confidenceSummary;
 
   return (
-    <>
-      {/* Google Fonts — cargamos aquí para no tocar el index.html del proyecto */}
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=DM+Mono:wght@400;500&display=swap"
-      />
+    <section className="bg-[#f3f7f3] dark:bg-gray-700 border border-[#c5e1a5] dark:border-gray-600 rounded-2xl p-5 w-full transition-colors">
+      {/* Título de sección */}
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-lg">🔬</span>
+        <h3 className="m-0 text-[#0d1b0d] dark:text-gray-100 text-sm font-bold uppercase tracking-wider transition-colors">
+          Nivel de Confianza del Análisis
+        </h3>
+      </div>
 
-      <section style={panelWrapperStyle}>
-        {/* Título de sección */}
-        <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "4px" }}>
-          <span style={{ fontSize: "18px" }}>🔬</span>
-          <h3
-            style={{
-              margin: 0,
-              color: "#e5e7eb",
-              fontSize: "14px",
-              fontWeight: "600",
-              fontFamily: "'DM Sans', sans-serif",
-              letterSpacing: "0.06em",
-              textTransform: "uppercase",
-            }}
-          >
-            Nivel de Confianza del Análisis
-          </h3>
-        </div>
+      <p className="mt-0 mb-4 text-[#475569] dark:text-gray-400 text-xs leading-relaxed transition-colors">
+        Porcentaje estadístico de certeza de cada modelo de IA utilizado en el análisis.
+      </p>
 
-        <p
-          style={{
-            margin: "0 0 16px",
-            color: "#6b7280",
-            fontSize: "12px",
-            fontFamily: "'DM Sans', sans-serif",
-            lineHeight: 1.5,
-          }}
-        >
-          Porcentaje estadístico de certeza de cada modelo de IA utilizado en el análisis.
-        </p>
+      {/* Barras de los dos modelos */}
+      <div className="flex flex-col gap-3">
+        <ConfidenceBar modelKey="damage_model" data={damage_model} animDelay={0} />
+        <ConfidenceBar modelKey="ripeness_model" data={ripeness_model} animDelay={150} />
+      </div>
 
-        {/* Barras de los dos modelos */}
-        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-          <ConfidenceBar modelKey="damage_model" data={damage_model} animDelay={0} />
-          <ConfidenceBar modelKey="ripeness_model" data={ripeness_model} animDelay={150} />
-        </div>
-
-        {/* Nota técnica de transparencia */}
-        <p
-          style={{
-            margin: "16px 0 0",
-            color: "#4b5563",
-            fontSize: "11px",
-            fontFamily: "'DM Mono', monospace",
-            borderTop: "1px solid #1f1f1f",
-            paddingTop: "12px",
-            lineHeight: 1.6,
-          }}
-        >
-          ⓘ Los valores reflejan la certeza del modelo YOLOv8 entrenado sobre imágenes
-          de aguacate Hass. Umbrales: ≥85% Alta · ≥65% Media · &lt;65% Baja.
-        </p>
-      </section>
-    </>
+      {/* Nota técnica de transparencia */}
+      <p className="mt-4 mb-0 text-[#94a3b8] dark:text-gray-500 text-xs border-t border-[#c5e1a5] dark:border-gray-600 pt-3 leading-relaxed transition-colors">
+        ⓘ Los valores reflejan la certeza del modelo YOLOv8 entrenado sobre imágenes
+        de aguacate Hass. Umbrales: ≥85% Alta · ≥65% Media · &lt;65% Baja.
+      </p>
+    </section>
   );
 }
-
-// ─── Estilos ──────────────────────────────────────────────────────────────────
-
-const panelWrapperStyle = {
-  background: "#0a0a0a",
-  border: "1px solid #1f1f1f",
-  borderRadius: "16px",
-  padding: "20px",
-  width: "100%",
-  boxSizing: "border-box",
-};
 
 // ─── Skeleton mientras carga ──────────────────────────────────────────────────
 
 function SkeletonBar() {
   return (
-    <div
-      style={{
-        background: "#111",
-        border: "1px solid #1f1f1f",
-        borderRadius: "12px",
-        padding: "18px 20px",
-        height: "120px",
-        animation: "pulse 1.5s ease-in-out infinite",
-      }}
-    >
-      <style>{`@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }`}</style>
-    </div>
+    <div className="bg-[#e4ede4] dark:bg-gray-600 rounded-2xl p-5 h-28 mb-3 animate-pulse transition-colors" />
   );
 }

--- a/frontend/src/app/pages/DashboardPage.jsx
+++ b/frontend/src/app/pages/DashboardPage.jsx
@@ -3,10 +3,17 @@ import { useNavigate } from "react-router";
 import Logo from "../components/Logo";
 import ThemeToggle from "../components/ThemeToggle";
 import ConfidencePanel from "../components/ConfidencePanel";
+import { useAuth } from "../contexts/AuthContext";
 
 export default function DashboardPage() {
   const navigate = useNavigate();
-  
+  const { user, logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate("/");
+  };
+
   // Estados
   const [selectedImage, setSelectedImage] = useState(null);
   const [imageFile, setImageFile] = useState(null);
@@ -139,6 +146,15 @@ export default function DashboardPage() {
               </button>
             </nav>
             <ThemeToggle />
+            {user && (
+              <button
+                onClick={handleLogout}
+                className="flex items-center gap-1.5 bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 px-3 py-1.5 rounded-full text-sm font-semibold hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors"
+              >
+                <span>🚪</span>
+                Salir
+              </button>
+            )}
           </div>
         </div>
       </header>

--- a/frontend/src/app/pages/MarketplacePage.jsx
+++ b/frontend/src/app/pages/MarketplacePage.jsx
@@ -2,11 +2,18 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import Logo from "../components/Logo";
 import ThemeToggle from "../components/ThemeToggle";
+import { useAuth } from "../contexts/AuthContext";
 
 export default function MarketplacePage() {
   const navigate = useNavigate();
+  const { user, logout } = useAuth();
   const [selectedLot, setSelectedLot] = useState(null);
   const [filter, setFilter] = useState("todos");
+
+  const handleLogout = () => {
+    logout();
+    navigate("/");
+  };
 
   const lots = [
     {
@@ -102,6 +109,15 @@ export default function MarketplacePage() {
               </button>
             </nav>
             <ThemeToggle />
+            {user && (
+              <button
+                onClick={handleLogout}
+                className="flex items-center gap-1.5 bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 px-3 py-1.5 rounded-full text-sm font-semibold hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors"
+              >
+                <span>🚪</span>
+                Salir
+              </button>
+            )}
           </div>
         </div>
       </header>

--- a/frontend/src/app/pages/ProfilePage.jsx
+++ b/frontend/src/app/pages/ProfilePage.jsx
@@ -72,6 +72,13 @@ export default function ProfilePage() {
               </button>
             </nav>
             <ThemeToggle />
+            <button
+              onClick={handleLogout}
+              className="flex items-center gap-1.5 bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 px-3 py-1.5 rounded-full text-sm font-semibold hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors"
+            >
+              <span>🚪</span>
+              Salir
+            </button>
           </div>
         </div>
       </header>


### PR DESCRIPTION
…button

- ConfidencePanel now uses light/dark Tailwind classes matching the dashboard style (bg-[#f3f7f3]/gray-700, green borders, adaptive text colors) instead of hardcoded dark backgrounds
- Added global logout button (🚪 Salir) to the header of Dashboard, Marketplace, and Profile pages — visible only when user is authenticated, positioned next to ThemeToggle